### PR TITLE
Use translate=no properties

### DIFF
--- a/data/io.github.cleomenezesjr.aurea.metainfo.xml.in
+++ b/data/io.github.cleomenezesjr.aurea.metainfo.xml.in
@@ -14,7 +14,7 @@
   <url type="homepage">https://github.com/CleoMenezesJr/Aurea</url>
   <url type="bugtracker">https://github.com/CleoMenezesJr/Aurea/issues</url>
   <launchable type="desktop-id">io.github.cleomenezesjr.aurea.desktop</launchable>
-  <developer_name translatable="no">Cleo Menezes Jr.</developer_name>
+  <developer_name translate="no">Cleo Menezes Jr.</developer_name>
   <branding>
     <color type="primary" scheme_preference="light">#f883b1</color>
     <color type="primary" scheme_preference="dark">#9c174c</color>
@@ -40,7 +40,7 @@
   <content_rating type="oars-1.1" />
   <releases>
     <release version="1.5" date="2024-09-21">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>GNOME 47 support</li>
           <li>Hot reload banner when metainfo is edited</li>
@@ -52,14 +52,14 @@
       </description>
     </release>
     <release version="1.4" date="2024-05-31">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Fixed issue with some misplaced screenshots</li>
         </ul>
       </description>
     </release>
     <release version="1.3" date="2024-05-29">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Ability to drag and drop metainfo file</li>
           <li>Enable file opening directly from the file manager</li>
@@ -70,14 +70,14 @@
       </description>
     </release>
     <release version="1.2" date="2024-05-05">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Update branding colors</li>
         </ul>
       </description>
     </release>
     <release version="1.0" date="2024-04-25">
-      <description translatable="no">
+      <description translate="no">
         <p>First stable release</p>
       </description>
     </release>


### PR DESCRIPTION
It appears that the appstream project no longer supports `translatable=no` properties, and gettext extract them as translatable.